### PR TITLE
Fix couple of comments / includes

### DIFF
--- a/wavelet-matrix.cpp
+++ b/wavelet-matrix.cpp
@@ -43,7 +43,7 @@ struct WaveMatrixSucc {
   }
 
   // Count occurrences of number c until position i.
-  // ie, occurrences of c in positions [i,j]
+  // ie, occurrences of c in positions [0,i]
   int rank(int c, int i) const {
     int p = -1;
     for (uint l = 0; l < height; ++l) {

--- a/wavelet-tree.cpp
+++ b/wavelet-tree.cpp
@@ -31,7 +31,7 @@ struct WaveTreeSucc {
   }
 
   // Count occurrences of number c until position i.
-  // ie, occurrences of c in positions [i,j]
+  // ie, occurrences of c in positions [0,i]
   int rank(int c, int i) const {
     // Internally we consider an interval open on the left: [0, i)
     i++;

--- a/wavelet-tree.cpp
+++ b/wavelet-tree.cpp
@@ -33,7 +33,7 @@ struct WaveTreeSucc {
   // Count occurrences of number c until position i.
   // ie, occurrences of c in positions [0,i]
   int rank(int c, int i) const {
-    // Internally we consider an interval open on the left: [0, i)
+    // Internally we consider an interval open on the right: [0, i)
     i++;
     int L = 0, U = s-1, u = 1, M, r;
     while (L != U) {
@@ -50,7 +50,7 @@ struct WaveTreeSucc {
   // Find the k-th smallest element in positions [i,j].
   // The smallest element is k=1
   int quantile(int k, int i, int j) const {
-    // internally we we consider an interval open on the left:  [i, j)
+    // internally we we consider an interval open on the right:  [i, j)
     j++;
     int L = 0, U = s-1, u = 1, M, ri, rj;
     while (L != U) {

--- a/wavelet-tree.cpp
+++ b/wavelet-tree.cpp
@@ -1,6 +1,5 @@
 #include<vector>
 #include<algorithm>
-#include "bitmap.hpp"
 using namespace std;
 typedef vector<int>::iterator iter;
 


### PR DESCRIPTION
The comments for the rank-methods contained a wrong interval, and also the comments about the open interval contained errors. 

Additionally I remove the `#include "bitmap.hpp"` from `wavelet-tree.cpp`, because it is not used in this file. 